### PR TITLE
Demolish-Mode Feature

### DIFF
--- a/public/index.pug
+++ b/public/index.pug
@@ -75,6 +75,11 @@ html(lang='en')
                a#spawner3.spawner(href="?spawners=3") 3
                a#spawner4.spawner(href="?spawners=4") 4
         hr
+        div.switch-box
+          label.switch
+            input(type='checkbox')#demolish-toggle
+            span.slider
+          label#switch-text(for="demolish-toggle") Start demolishing
         footer
           div
             | Inert

--- a/public/index.pug
+++ b/public/index.pug
@@ -79,7 +79,7 @@ html(lang='en')
           label.switch
             input(type='checkbox')#demolish-toggle
             span.slider
-          label#switch-text(for="demolish-toggle") Start demolishing
+          label#switch-text(for="demolish-toggle") Demolish-Mode: Off
         footer
           div
             | Inert

--- a/public/styles/styles.less
+++ b/public/styles/styles.less
@@ -169,6 +169,62 @@ body {
       }
     }
 
+    .switch-box {
+      display: flex;
+      justify-content: space-evenly;
+      align-items: center;
+      margin: 1rem 0;
+    }
+
+    .switch {
+      font-size: 15px;
+      position: relative;
+      display: inline-block;
+      width: 3.5rem;
+      height: 2rem;
+    }
+    
+    #switch-text {
+      font-size: 1.2rem;
+      cursor: pointer;
+    }
+
+    .switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+    
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      inset: 0;
+      border: 2px solid #414141;
+      border-radius: 50px;
+      transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    }
+    
+    .slider:before {
+      position: absolute;
+      content: "";
+      height: 1.4rem;
+      width: 1.4rem;
+      left: 0.2rem;
+      bottom: 0.2rem;
+      background-color: #2fcc71;
+      border-radius: inherit;
+      transition: all 0.4s cubic-bezier(0.23, 1, 0.320, 1);
+    }
+    
+    .switch input:checked + .slider {
+      box-shadow: 0 0 20px var(--accent);
+      border: 2px solid var(--accent);
+    }
+    
+    .switch input:checked + .slider:before {
+      transform: translateX(1.5em);
+    }
+
     footer {
       text-align: center;
       font-size: 14px;

--- a/src/InterfaceManager.ts
+++ b/src/InterfaceManager.ts
@@ -19,12 +19,14 @@ class InterfaceManager {
     private towersStatsElement = document.getElementById('towers-stats')!;
     private waveDelayElement = document.getElementById('delay')!;
     private gameOverElement = document.getElementById('game-over')!;
+    private demolishToggleElement = document.getElementById('demolish-toggle')!;
     public snackbar = new Snackbar();
 
     constructor() {
         this.versionElement.textContent = 'v' + version;
         controls.on('focusout', this.showFocusLost.bind(this));
         controls.on('focusin', this.hideFocusLost.bind(this));
+        this.demolishToggleElement.onclick = this.handleDemolishToggle.bind(this);
 
         if(!controls.tabHasFocus()) {
             this.showFocusLost()
@@ -33,6 +35,10 @@ class InterfaceManager {
         document.getElementById('spawner' + queryParamsManager.getDifficulty())!.classList.add('active')
 
         this.setTowers()
+    }
+
+    displaySnackbarToast(text: string, duration: number = 3000) {
+        this.snackbar.toast(text, duration);
     }
 
     showFocusLost() {
@@ -61,6 +67,18 @@ class InterfaceManager {
         this.cashElement.textContent = String(cash);
     }
 
+    handleDemolishToggle(e: Event) {
+        const isChecked = e.target instanceof HTMLInputElement && e.target.checked;
+
+        towerPlacer.toggleDemolishMode(isChecked);
+
+        if (isChecked) {
+            this.displaySnackbarToast('🚧 Click on a tower to demolish it. 🚧', 1500)
+        } else {
+            this.displaySnackbarToast('🚧 Demolish-Mode disabled 🚧', 1500)
+        }
+    }
+
     private setTowers() {
         const towers = [
             CanonTower,
@@ -84,6 +102,10 @@ class InterfaceManager {
             tower.draw(ctx);
 
             canvas.onclick = () => {
+                if ((this.demolishToggleElement as HTMLInputElement).checked) {
+                    towerPlacer.toggleDemolishMode(false);
+                    (this.demolishToggleElement as HTMLInputElement).click();
+                }
                 towerPlacer.place(TowerClass);
                 this.showTowerStats(tower);
             };
@@ -107,7 +129,7 @@ class InterfaceManager {
             <table class="table5050">
                 <tr><td>Cost: </td><td class="accent">${tower.cost} ¢</td></tr>
                 <tr><td>Aim radius:</td><td class="accent">${tower.aimRadius}</td></tr>
-                ${tower.damage > 0 ? `
+                ${typeof tower.damage === 'number' && tower.damage > 0 ? `
                     <tr><td>Damage:</td><td class="accent">${damage}</td></tr>
                     <tr><td>Reload:</td><td class="accent">${reloadDuration.toFixed(3)} s</td></tr>
                     <tr><td title="Damage Per Second">DPS:</td><td class="accent">${dps}</td></tr>

--- a/src/InterfaceManager.ts
+++ b/src/InterfaceManager.ts
@@ -20,6 +20,7 @@ class InterfaceManager {
     private waveDelayElement = document.getElementById('delay')!;
     private gameOverElement = document.getElementById('game-over')!;
     private demolishToggleElement = document.getElementById('demolish-toggle')!;
+    private demolishToggleLabelElement = document.getElementById('switch-text')!;
     public snackbar = new Snackbar();
 
     constructor() {
@@ -74,8 +75,10 @@ class InterfaceManager {
 
         if (isChecked) {
             this.displaySnackbarToast('🚧 Click on a tower to demolish it. 🚧', 1500)
+            this.demolishToggleLabelElement.textContent = 'Demolish-Mode: On';
         } else {
             this.displaySnackbarToast('🚧 Demolish-Mode disabled 🚧', 1500)
+            this.demolishToggleLabelElement.textContent = 'Demolish-Mode: Off';
         }
     }
 

--- a/src/Map.ts
+++ b/src/Map.ts
@@ -127,6 +127,13 @@ class Map extends EventEmitter {
         return false;
     }
 
+    deleteElement(i: number, j: number) {
+        if (this.grid[i] && this.grid[i][j] !== undefined) {
+            this.grid[i][j] = 0;
+            this.invalidatePathsCache();
+        }
+    }
+    
     addBase(i: number, j: number, isHome = false): Base {
         const base = new Base(i, j, Map.TILE_SIZE, isHome);
         this.grid[i][j] = base;

--- a/src/TowerPlacer.ts
+++ b/src/TowerPlacer.ts
@@ -14,11 +14,27 @@ class TowerPlacer extends Renderable {
     private j: number = 0;
     private i: number = 0;
     private shouldBeDrawn = false;
+    private isDemolishMode = false;
 
     constructor() {
         super();
 
         controls.on('click', () => {
+            if (this.isDemolishMode) {
+
+                const mouse = canvas.transformMatrix!.inverse().transformPoint(controls.mouse)
+                const i = Math.floor(mouse.x / Map.TILE_SIZE);
+                const j = Math.floor(mouse.y / Map.TILE_SIZE);
+
+                if (i >= 0 && i < map.grid.length && j >= 0 && j < map.grid[0].length) {
+                    // Check if the element is a tower
+                    if (map.grid[i][j] instanceof Tower) {
+                        map.deleteElement(i, j);
+                    }
+                }
+                return;
+            }
+
             if (this.placing && this.canBePlaced()) {
                 if (cashManager.canWithdraw(this.tower.cost)) {
                     cashManager.withdraw(this.tower.cost)
@@ -86,6 +102,12 @@ class TowerPlacer extends Renderable {
         this.placing = true;
 
         this.tower = new TowerClass(0, 0, Map.TILE_SIZE);
+    }
+
+    toggleDemolishMode(isChecked: boolean) {
+        this.isDemolishMode = isChecked;
+        this.placing = false;
+        this.shouldBeDrawn = false;
     }
 }
 


### PR DESCRIPTION
Hello there 👋

I really enjoyed your Tower-Defence game, but sometimes I miss clicked when placing towers on the grid.

I am currently training to get more used to read and understand codebases from other developers and to add features or fix bugs.
So I thought I'll implement a demolish feature to destroy misplaced towers.

----------------

following changes were made:

* Added new UI Elements
    * A checkbox toggle switch to toggle the Demolish-Mode
    * Snackbar toasts to inform user about enabling and disabling of Demolish-Mode
* Demolishing of misplaced towers
    * Only towers can be demolished - every other structure will be ignored
    * when clicking on a tower in the interface to place another, the Demolish-Mode will be disabled

------------

Check out this little clip which presents the feature

https://github.com/CorentinTh/inert/assets/122015710/6f289f9a-81b8-4721-89dc-142a07a13af5

-------------


Hopefully this feature is appreciated :)